### PR TITLE
[MobilePlayerViewController] Hiding action button on initialization and presenting it when acitivityItems is set.

### DIFF
--- a/MobilePlayer/MobilePlayerViewController.swift
+++ b/MobilePlayer/MobilePlayerViewController.swift
@@ -174,14 +174,8 @@ public class MobilePlayerViewController: MPMoviePlayerViewController {
         }
       },
       forControlEvents: .TouchUpInside)
-
-    if let actionButton = getViewForElementWithIdentifier("action") as? Button {
-      actionButton.addCallback(
-        {
-          self.showContentActions(actionButton)
-        },
-        forControlEvents: .TouchUpInside)
-    }
+    
+    getViewForElementWithIdentifier("action")?.hidden = true
 
     (getViewForElementWithIdentifier("play") as? ToggleButton)?.addCallback(
       {
@@ -338,7 +332,22 @@ public class MobilePlayerViewController: MPMoviePlayerViewController {
   /// button is pressed (if it exists). If content is playing, it is paused automatically at presentation and will
   /// continue after the controller is dismissed. Override `showContentActions()` if you want to change the button's
   /// behavior.
-  public var activityItems: [AnyObject]?
+    public var activityItems: [AnyObject]? {
+        didSet {
+            if let items = self.activityItems, let actionButton = getViewForElementWithIdentifier("action") as? Button {
+                if !items.isEmpty {
+                    actionButton.hidden = false
+                    actionButton.addCallback(
+                        {
+                            self.showContentActions(actionButton)
+                        },
+                        forControlEvents: .TouchUpInside)
+                } else {
+                    actionButton.hidden = true
+                }
+            }
+        }
+    }
 
   /// Method that is called when a control interface button with identifier "action" is tapped. Presents a
   /// `UIActivityViewController` with `activityItems` set as its activity items. If content is playing, it is paused
@@ -349,7 +358,7 @@ public class MobilePlayerViewController: MPMoviePlayerViewController {
   ///   - sourceView: On iPads the activity view controller is presented as a popover and a source view needs to
   ///     provided or a crash will occur.
   public func showContentActions(sourceView: UIView? = nil) {
-    guard let activityItems = activityItems else { return }
+    guard let activityItems = activityItems where !activityItems.isEmpty else { return }
     let wasPlaying = (state == .Playing)
     moviePlayer.pause()
     let activityVC = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)


### PR DESCRIPTION
Fixes #120 and hides social action button on init and shows it when `activityItems` is set.

`getViewForElementWithIdentifier("action")?.hidden = true` doesn't need to be used by the user.

These examples will have the action button hidden.
```swift
let playerVC = MobilePlayerViewController(contentURL: videoURL)
playerVC.title = "Vanilla Player - \(videoTitle)"
presentMoviePlayerViewControllerAnimated(playerVC)
```
```swift
let playerVC = MobilePlayerViewController(contentURL: videoURL)
playerVC.title = "Vanilla Player - \(videoTitle)"
playerVC.activityItems = []
presentMoviePlayerViewControllerAnimated(playerVC)
```
This example will have the action button shown.
```swift
let playerVC = MobilePlayerViewController(contentURL: videoURL)
playerVC.title = "Vanilla Player - \(videoTitle)"
playerVC.activityItems = [videoURL]
presentMoviePlayerViewControllerAnimated(playerVC)
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/mobileplayer/mobileplayer-ios/121)
<!-- Reviewable:end -->
