### PR TITLE
Fix memory leaks caused by retain loops

### DIFF
--- a/MobilePlayer/Views/Slider.swift
+++ b/MobilePlayer/Views/Slider.swift
@@ -16,7 +16,7 @@ protocol SliderDelegate: class {
 
 class Slider: UIView {
   let config: SliderConfig
-  var delegate: SliderDelegate?
+  weak var delegate: SliderDelegate?
   var minimumValue = Float(0)    { didSet { setNeedsLayout() } }
   var value = Float(0)           { didSet { setNeedsLayout() } }
   var availableValue = Float(0)  { didSet { setNeedsLayout() } }


### PR DESCRIPTION
I performed a simple test which revealed a problem with MobilePlayerViewController. Here's my code:

```swift
class ViewController: UIViewController {
    
    private var appeared = false
    
    override func viewDidAppear(animated: Bool) {
        super.viewDidAppear(animated)
        
        guard appeared == false else {
            return
        }
        
        appeared = true
        
        weak var ctrlSelf = self
        
        delay(1.0) {
            guard let ctrl = ctrlSelf else {
                return
            }
            
            let url = NSURL(string: "somevideo.mp4")!
            let player = MobilePlayerViewController(contentURL: url)
            
            player.title = "Test"
            player.activityItems = [url]
            
            ctrl.presentMoviePlayerViewControllerAnimated(player)
            
            delay(1.0) {
                guard let ctrl = ctrlSelf else {
                    return
                }
                
                ctrl.dismissMoviePlayerViewControllerAnimated()
            }
        }
    }
    
}
```

After dismissing video controller it does not get deallocated. It has terrible impact in case video did not start playing before controller is dismissed — controller becomes invisible and after some time sound starts playing.

I was not able to test all possible cases but current fixes eliminate this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mobileplayer/mobileplayer-ios/137)
<!-- Reviewable:end -->