### PR TITLE
changed visibility of showContentActions

### DIFF
--- a/MobilePlayer/MobilePlayerViewController.swift
+++ b/MobilePlayer/MobilePlayerViewController.swift
@@ -366,7 +366,7 @@ open class MobilePlayerViewController: MPMoviePlayerViewController {
   /// parameters:
   ///   - sourceView: On iPads the activity view controller is presented as a popover and a source view needs to
   ///     provided or a crash will occur.
-  public func showContentActions(sourceView: UIView? = nil) {
+  open func showContentActions(sourceView: UIView? = nil) {
     guard let activityItems = activityItems, !activityItems.isEmpty else { return }
     let wasPlaying = (state == .playing)
     moviePlayer.pause()


### PR DESCRIPTION
Given Swift3 new accessors, it's not possible to override `showContentActions`. Changed the visibility from `public` to `open` to enable override.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mobileplayer/mobileplayer-ios/171)
<!-- Reviewable:end -->
