### PR TITLE
Fix StatusBar is modified by MPMoviePlayerViewController

### DIFF
--- a/MobilePlayer/MobilePlayerViewController.swift
+++ b/MobilePlayer/MobilePlayerViewController.swift
@@ -275,12 +275,13 @@ open class MobilePlayerViewController: MPMoviePlayerViewController {
   /// - parameters:
   ///  - animated: If `true`, the disappearance of the view is being animated.
   open override func viewWillDisappear(_ animated: Bool) {
+    // Restore status bar appearance.
+    if let previousStatusBarHidden = previousStatusBarHiddenValue {
+        UIApplication.shared.isStatusBarHidden = previousStatusBarHidden
+        setNeedsStatusBarAppearanceUpdate()
+    }
     super.viewWillDisappear(animated)
     stop()
-    // Restore status bar appearance.
-    guard let previousStatusBarHiddenValue = previousStatusBarHiddenValue else { return }
-    UIApplication.shared.isStatusBarHidden = previousStatusBarHiddenValue
-    setNeedsStatusBarAppearanceUpdate()
   }
 
   // MARK: Deinitialization


### PR DESCRIPTION
Fix StatusBar is modified by MPMoviePlayerViewController

|       |       |
|:------|:------|
| Swift | 3     |
| XCode | 8.3.1 |
| iOS   | 10.3  |

MobilePlayerViewController.swift: 

```swift
open override func viewWillAppear(_ animated: Bool) {
    // ⚠️  isStatusBarHidden: false
    super.viewWillAppear(animated)
    // ⚠️  isStatusBarHidden: true
    previousStatusBarHiddenValue = UIApplication.shared.isStatusBarHidden
    // ⚠️  previousStatusBarHiddenValue: true
    UIApplication.shared.isStatusBarHidden = true
    setNeedsStatusBarAppearanceUpdate()
  }
```

```swift
open override func viewWillDisappear(_ animated: Bool) {
    // ⚠️  isStatusBarHidden: true
    super.viewWillDisappear(animated)
    // ⚠️  isStatusBarHidden: false
    guard let previousStatusBarHiddenValue = previousStatusBarHiddenValue else { return }
    UIApplication.shared.isStatusBarHidden = previousStatusBarHiddenValue
    setNeedsStatusBarAppearanceUpdate()
    // ⚠️  isStatusBarHidden: true
    stop()
  }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mobileplayer/mobileplayer-ios/172)
<!-- Reviewable:end -->
