### PR TITLE
Specify SWIFT_VERSION environment variable

### DIFF
--- a/MobilePlayer.podspec
+++ b/MobilePlayer.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.frameworks = 'UIKit', 'MediaPlayer'
   s.source_files = 'MobilePlayer/**/*.swift'
   s.resource_bundle  = { 'MobilePlayer' => 'MobilePlayer/**/*.png' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '3.2' }
 end


### PR DESCRIPTION
Forces CocoaPods to specify the `SWIFT_VERSION` environment variable, avoiding Xcode to give problems when using as a Pod in an Objective-C project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mobileplayer/mobileplayer-ios/181)
<!-- Reviewable:end -->
