### PR TITLE
Adding a way to choose what activities are exluded when sharing the video

### DIFF
--- a/MobilePlayer/MobilePlayerViewController.swift
+++ b/MobilePlayer/MobilePlayerViewController.swift
@@ -358,6 +358,14 @@ open class MobilePlayerViewController: MPMoviePlayerViewController {
       getViewForElementWithIdentifier("action")?.isHidden = isEmpty
     }
   }
+    
+  /// An array of activity types that will be excluded when presenting a `UIActivityViewController`
+  public var excludedActivityTypes: [UIActivityType]? = [
+      .assignToContact,
+      .saveToCameraRoll,
+      .postToVimeo,
+      .airDrop
+  ]
 
   /// Method that is called when a control interface button with identifier "action" is tapped. Presents a
   /// `UIActivityViewController` with `activityItems` set as its activity items. If content is playing, it is paused
@@ -372,12 +380,7 @@ open class MobilePlayerViewController: MPMoviePlayerViewController {
     let wasPlaying = (state == .playing)
     moviePlayer.pause()
     let activityVC = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-    activityVC.excludedActivityTypes =  [
-      .assignToContact,
-      .saveToCameraRoll,
-      .postToVimeo,
-      .airDrop
-    ]
+    activityVC.excludedActivityTypes =  excludedActivityTypes
     activityVC.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
       if wasPlaying {
         self.moviePlayer.play()
@@ -640,3 +643,4 @@ extension MobilePlayerViewController: SliderDelegate {
     }
   }
 }
+


### PR DESCRIPTION
In my project I want the user to be able to save the video to "Camera roll". This is not possible because `.saveToCameraRoll` is excluded for the `UIActivityViewController` in the current implementation.

This PR adds a way to select what is excluded and what is not from the `UIActivityViewController`. The default behavior stays the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mobileplayer/mobileplayer-ios/183)
<!-- Reviewable:end -->
