### PR TITLE
Open access for handleContentTap()

### DIFF
--- a/MobilePlayer/MobilePlayerViewController.swift
+++ b/MobilePlayer/MobilePlayerViewController.swift
@@ -422,7 +422,7 @@ open class MobilePlayerViewController: MPMoviePlayerViewController {
 
   /// Hides/shows controls when content area is tapped once. Overriding this method is recommended if you want to change
   /// this behavior.
-  public func handleContentTap() {
+  open func handleContentTap() {
     controlsHidden = !controlsHidden
   }
 


### PR DESCRIPTION
Makes handleContentTap() function access level open so that it can be overridden when inheriting MobilePlayerViewController.

Fixes #200